### PR TITLE
Add types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "__DEV__": false
   },
   "extends": ["plugin:react/recommended"],
+  "parser": "@typescript-eslint/parser",
 
   "plugins": ["react"],
   "rules": {
@@ -48,5 +49,13 @@
       "error",
       { "anonymous": "always", "named": "never" }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "no-unused-vars": "off"
+      }
+    }
+  ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 es
-lib
+/lib
 umd
 node_modules
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lib",
     "umd"
   ],
+  "types": "types/index.d.ts",
   "main": "lib/index",
   "module": "es/index",
   "jsnext:main": "es/index",
@@ -20,7 +21,7 @@
     "build-es": "rimraf es && cross-env BABEL_ENV=es babel ./modules -d es --ignore __tests__",
     "build-umd": "cross-env NODE_ENV=development webpack --mode development ./modules/index.js -o umd",
     "build-min": "cross-env NODE_ENV=production webpack --mode production ./modules/index.js -o umd",
-    "lint": "eslint modules scripts *.js",
+    "lint": "eslint modules types scripts *.js --ext .js --ext .ts",
     "prepublishOnly": "node ./scripts/build.js",
     "test": "npm run lint && npm run test-node && npm run test-browser",
     "test-browser": "cross-env NODE_ENV=test karma start",
@@ -56,7 +57,13 @@
     "warning": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^18.0.0",
+    "@types/react": "^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/cli": "^7.26.4",
@@ -67,6 +74,7 @@
     "@babel/register": "^7.25.9",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.1.0",
+    "@typescript-eslint/parser": "^8.18.0",
     "babel-loader": "^9.2.1",
     "babel-plugin-dev-expression": "^0.2.3",
     "babel-plugin-istanbul": "^7.0.0",
@@ -96,6 +104,7 @@
     "react-dom": "^18.3.1",
     "rimraf": "^2.5.4",
     "style-loader": "^4.0.0",
+    "typescript": "^5.7.2",
     "webpack": "^5.97.1",
     "webpack-cli": "^5.1.4",
     "webpack-dev-middleware": "^7.4.2"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-is": "^18.3.1"
   },
   "dependencies": {
+    "@types/history": "3.2.5",
     "history": "^3.0.0",
     "hoist-non-react-statics": "^3.3.2",
     "invariant": "^2.2.1",
@@ -57,8 +58,8 @@
     "warning": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "@types/react": "^18.0.0"
+    "@types/react": "^18.0.0",
+    "react": "^18.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,72 @@
+// This is a fork from @types/react-router@3.0.28
+// Type definitions for . 3.0
+// Project: https://github.com/rackt/.
+// Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>
+//                 Yuichi Murata <https://github.com/mrk21>
+//                 Václav Ostrožlík <https://github.com/vasek17>
+//                 Nathan Brown <https://github.com/ngbrown>
+//                 Alex Wendland <https://github.com/awendland>
+//                 Kostya Esmukov <https://github.com/KostyaEsmukov>
+//                 John Reilly <https://github.com/johnnyreilly>
+//                 Karol Janyst <https://github.com/LKay>
+//                 Dovydas Navickas <https://github.com/DovydasNavickas>
+//                 Ross Allen <https://github.com/ssorallen>
+//                 Christian Gill <https://github.com/gillchristian>
+//                 Roman Nevolin <https://github.com/nulladdict>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.5
+
+export {
+  ChangeHook,
+  EnterHook,
+  InjectedRouter,
+  LeaveHook,
+  ParseQueryString,
+  RouteComponent,
+  RouteComponents,
+  RouteComponentProps,
+  RouteConfig,
+  RoutePattern,
+  RouterProps,
+  RouterState,
+  RedirectFunction,
+  StringifyQuery
+} from './lib/Router'
+export { LinkProps } from './lib/Link'
+export { IndexLinkProps } from './lib/IndexLink'
+export { RouteProps, PlainRoute } from './lib/Route'
+export { IndexRouteProps } from './lib/IndexRoute'
+export { RedirectProps } from './lib/Redirect'
+export { IndexRedirectProps } from './lib/IndexRedirect'
+export { WithRouterProps } from './lib/withRouter'
+
+/* components */
+export { default as Router } from './lib/Router'
+export { default as Link } from './lib/Link'
+export { default as IndexLink } from './lib/IndexLink'
+export { default as withRouter } from './lib/withRouter'
+
+/* components (configuration) */
+export { default as IndexRedirect } from './lib/IndexRedirect'
+export { default as IndexRoute } from './lib/IndexRoute'
+export { default as Redirect } from './lib/Redirect'
+export { default as Route } from './lib/Route'
+
+/* utils */
+export { createRoutes } from './lib/RouteUtils'
+export { default as RouterContext } from './lib/RouterContext'
+export { routerShape, locationShape } from './lib/PropTypes'
+export {
+  default as match,
+  MatchHistoryArgs,
+  MatchLocationArgs,
+  MatchCallback
+} from './lib/match'
+export { default as useRouterHistory } from './lib/useRouterHistory'
+export { formatPattern } from './lib/PatternUtils'
+export { default as applyRouterMiddleware } from './lib/applyRouterMiddleware'
+
+/* histories */
+export { default as browserHistory } from './lib/browserHistory'
+export { default as hashHistory } from './lib/hashHistory'
+export { default as createMemoryHistory } from './lib/createMemoryHistory'

--- a/types/lib/IndexLink.d.ts
+++ b/types/lib/IndexLink.d.ts
@@ -1,0 +1,15 @@
+import { ComponentClass, CSSProperties, HTMLProps } from 'react'
+import { Location, LocationDescriptor } from 'history'
+
+type ToLocationFunction = (location: Location) => LocationDescriptor;
+
+export interface IndexLinkProps extends HTMLProps<any> {
+    to: LocationDescriptor | ToLocationFunction;
+    activeClassName?: string | undefined;
+    activeStyle?: CSSProperties | undefined;
+}
+
+type IndexLink = ComponentClass<IndexLinkProps>;
+declare const IndexLink: IndexLink
+
+export default IndexLink

--- a/types/lib/IndexLink.d.ts
+++ b/types/lib/IndexLink.d.ts
@@ -1,15 +1,15 @@
-import { ComponentClass, CSSProperties, HTMLProps } from 'react'
+import { FunctionComponent, CSSProperties, HTMLProps } from 'react'
 import { Location, LocationDescriptor } from 'history'
 
 type ToLocationFunction = (location: Location) => LocationDescriptor;
 
 export interface IndexLinkProps extends HTMLProps<any> {
-    to: LocationDescriptor | ToLocationFunction;
-    activeClassName?: string | undefined;
-    activeStyle?: CSSProperties | undefined;
+  to: LocationDescriptor | ToLocationFunction;
+  activeClassName?: string | undefined;
+  activeStyle?: CSSProperties | undefined;
 }
 
-type IndexLink = ComponentClass<IndexLinkProps>;
+type IndexLink = FunctionComponent<IndexLinkProps>;
 declare const IndexLink: IndexLink
 
 export default IndexLink

--- a/types/lib/IndexRedirect.d.ts
+++ b/types/lib/IndexRedirect.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, ClassAttributes } from 'react'
+import { FunctionComponent, ClassAttributes } from 'react'
 import { RoutePattern } from '..'
 import { Query } from 'history'
 
@@ -7,7 +7,7 @@ export interface IndexRedirectProps extends ClassAttributes<any> {
   query?: Query | undefined;
 }
 
-type IndexRedirect = ComponentClass<IndexRedirectProps>;
+type IndexRedirect = FunctionComponent<IndexRedirectProps>;
 declare const IndexRedirect: IndexRedirect
 
 export default IndexRedirect

--- a/types/lib/IndexRedirect.d.ts
+++ b/types/lib/IndexRedirect.d.ts
@@ -1,0 +1,13 @@
+import { ComponentClass, ClassAttributes } from 'react'
+import { RoutePattern } from '..'
+import { Query } from 'history'
+
+export interface IndexRedirectProps extends ClassAttributes<any> {
+  to: RoutePattern;
+  query?: Query | undefined;
+}
+
+type IndexRedirect = ComponentClass<IndexRedirectProps>;
+declare const IndexRedirect: IndexRedirect
+
+export default IndexRedirect

--- a/types/lib/IndexRoute.d.ts
+++ b/types/lib/IndexRoute.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, ClassAttributes } from 'react'
+import { FunctionComponent, ClassAttributes } from 'react'
 import { LocationState } from 'history'
 import {
   EnterHook,
@@ -23,7 +23,7 @@ export interface IndexRouteProps<Props = any> {
   onLeave?: LeaveHook | undefined;
 }
 
-type IndexRoute = ComponentClass<IndexRouteProps>;
+type IndexRoute = FunctionComponent<IndexRouteProps>;
 declare const IndexRoute: IndexRoute
 
 export default IndexRoute

--- a/types/lib/IndexRoute.d.ts
+++ b/types/lib/IndexRoute.d.ts
@@ -1,0 +1,29 @@
+import { ComponentClass, ClassAttributes } from 'react'
+import { LocationState } from 'history'
+import {
+  EnterHook,
+  ChangeHook,
+  LeaveHook,
+  RouteComponent,
+  RouteComponents,
+  RouterState
+} from '..'
+
+type ComponentCallback = (err: any, component: RouteComponent) => any;
+type ComponentsCallback = (err: any, components: RouteComponents) => any;
+
+export interface IndexRouteProps<Props = any> {
+  component?: RouteComponent | undefined;
+  components?: RouteComponents | undefined;
+  props?: Props | undefined;
+  getComponent?(nextState: RouterState, callback: ComponentCallback): void;
+  getComponents?(nextState: RouterState, callback: ComponentsCallback): void;
+  onEnter?: EnterHook | undefined;
+  onChange?: ChangeHook | undefined;
+  onLeave?: LeaveHook | undefined;
+}
+
+type IndexRoute = ComponentClass<IndexRouteProps>;
+declare const IndexRoute: IndexRoute
+
+export default IndexRoute

--- a/types/lib/Link.d.ts
+++ b/types/lib/Link.d.ts
@@ -1,0 +1,11 @@
+import { ComponentClass, CSSProperties, HTMLProps } from 'react'
+import { IndexLinkProps } from './IndexLink'
+
+export interface LinkProps extends IndexLinkProps {
+  onlyActiveOnIndex?: boolean | undefined;
+}
+
+type Link = ComponentClass<LinkProps>;
+declare const Link: Link
+
+export default Link

--- a/types/lib/Link.d.ts
+++ b/types/lib/Link.d.ts
@@ -1,11 +1,11 @@
-import { ComponentClass, CSSProperties, HTMLProps } from 'react'
+import { FunctionComponent, CSSProperties, HTMLProps } from 'react'
 import { IndexLinkProps } from './IndexLink'
 
 export interface LinkProps extends IndexLinkProps {
   onlyActiveOnIndex?: boolean | undefined;
 }
 
-type Link = ComponentClass<LinkProps>;
+type Link = FunctionComponent<LinkProps>;
 declare const Link: Link
 
 export default Link

--- a/types/lib/PatternUtils.d.ts
+++ b/types/lib/PatternUtils.d.ts
@@ -1,0 +1,12 @@
+import { RoutePattern } from '..'
+
+export function formatPattern(pattern: RoutePattern, params: any): string;
+
+export function matchPattern(
+  pattern: string,
+  pathname: string
+): {
+  remainingPathname: string;
+  paramNames: string[];
+  paramValues: string[];
+} | null;

--- a/types/lib/PropTypes.d.ts
+++ b/types/lib/PropTypes.d.ts
@@ -1,0 +1,22 @@
+import { Requireable, Validator } from 'react'
+
+export interface RouterShape extends Validator<any> {
+    push: Requireable<any>;
+    replace: Requireable<any>;
+    go: Requireable<any>;
+    goBack: Requireable<any>;
+    goForward: Requireable<any>;
+    setRouteLeaveHook: Requireable<any>;
+    isActive: Requireable<any>;
+}
+
+export interface LocationShape extends Validator<any> {
+    pathname: Requireable<any>;
+    search: Requireable<any>;
+    state: any;
+    action: Requireable<any>;
+    key: any;
+}
+
+export const routerShape: RouterShape
+export const locationShape: LocationShape

--- a/types/lib/Redirect.d.ts
+++ b/types/lib/Redirect.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, ClassAttributes } from 'react'
+import { FunctionComponent, ClassAttributes } from 'react'
 import { RoutePattern } from '..'
 import { IndexRedirectProps } from './IndexRedirect'
 import { Query } from 'history'
@@ -7,7 +7,7 @@ export interface RedirectProps extends IndexRedirectProps {
   from: RoutePattern;
 }
 
-type Redirect = ComponentClass<RedirectProps>;
+type Redirect = FunctionComponent<RedirectProps>;
 declare const Redirect: Redirect
 
 export default Redirect

--- a/types/lib/Redirect.d.ts
+++ b/types/lib/Redirect.d.ts
@@ -1,0 +1,13 @@
+import { ComponentClass, ClassAttributes } from 'react'
+import { RoutePattern } from '..'
+import { IndexRedirectProps } from './IndexRedirect'
+import { Query } from 'history'
+
+export interface RedirectProps extends IndexRedirectProps {
+  from: RoutePattern;
+}
+
+type Redirect = ComponentClass<RedirectProps>;
+declare const Redirect: Redirect
+
+export default Redirect

--- a/types/lib/Route.d.ts
+++ b/types/lib/Route.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, ClassAttributes } from 'react'
+import { FunctionComponent, ClassAttributes } from 'react'
 import { LocationState } from 'history'
 import {
   EnterHook,
@@ -16,7 +16,7 @@ export interface RouteProps<Props = any> extends IndexRouteProps<Props> {
   path?: RoutePattern | undefined;
 }
 
-type Route = ComponentClass<RouteProps>;
+type Route = FunctionComponent<RouteProps>;
 declare const Route: Route
 
 export default Route

--- a/types/lib/Route.d.ts
+++ b/types/lib/Route.d.ts
@@ -1,0 +1,38 @@
+import { ComponentClass, ClassAttributes } from 'react'
+import { LocationState } from 'history'
+import {
+  EnterHook,
+  ChangeHook,
+  LeaveHook,
+  RouteComponent,
+  RouteComponents,
+  RoutePattern,
+  RouterState
+} from '..'
+import { IndexRouteProps } from './IndexRoute'
+
+export interface RouteProps<Props = any> extends IndexRouteProps<Props> {
+  children?: React.ReactNode;
+  path?: RoutePattern | undefined;
+}
+
+type Route = ComponentClass<RouteProps>;
+declare const Route: Route
+
+export default Route
+
+type RouteCallback = (err: any, route: PlainRoute) => void;
+type RoutesCallback = (err: any, routesArray: PlainRoute[]) => void;
+
+export interface PlainRoute<Props = any> extends RouteProps<Props> {
+  childRoutes?: PlainRoute[] | undefined;
+  getChildRoutes?(
+    partialNextState: LocationState,
+    callback: RoutesCallback
+  ): void;
+  indexRoute?: PlainRoute | undefined;
+  getIndexRoute?(
+    partialNextState: LocationState,
+    callback: RouteCallback
+  ): void;
+}

--- a/types/lib/RouteUtils.d.ts
+++ b/types/lib/RouteUtils.d.ts
@@ -1,0 +1,3 @@
+import { RouteConfig, PlainRoute } from '..'
+
+export function createRoutes(routes: RouteConfig): PlainRoute[];

--- a/types/lib/Router.d.ts
+++ b/types/lib/Router.d.ts
@@ -1,17 +1,14 @@
 import {
-  Component,
   ComponentClass,
   ClassAttributes,
   ReactNode,
-  FunctionComponent
+  ComponentType
 } from 'react'
 import {
-  Action,
   History,
   Href,
   Location,
   LocationDescriptor,
-  LocationKey,
   LocationState,
   Path,
   Pathname,
@@ -26,7 +23,7 @@ export interface Params {
 }
 
 export type RoutePattern = string;
-export type RouteComponent = ComponentClass<any> | FunctionComponent<any>;
+export type RouteComponent = ComponentType<any>;
 export interface RouteComponents {
   [name: string]: RouteComponent;
 }

--- a/types/lib/Router.d.ts
+++ b/types/lib/Router.d.ts
@@ -1,0 +1,113 @@
+import {
+  Component,
+  ComponentClass,
+  ClassAttributes,
+  ReactNode,
+  FunctionComponent
+} from 'react'
+import {
+  Action,
+  History,
+  Href,
+  Location,
+  LocationDescriptor,
+  LocationKey,
+  LocationState,
+  Path,
+  Pathname,
+  Query,
+  Search
+} from 'history'
+import { PlainRoute } from '..'
+import React = require('react');
+
+export interface Params {
+  [key: string]: string;
+}
+
+export type RoutePattern = string;
+export type RouteComponent = ComponentClass<any> | FunctionComponent<any>;
+export interface RouteComponents {
+  [name: string]: RouteComponent;
+}
+export type RouteConfig = ReactNode | PlainRoute | PlainRoute[];
+
+export type ParseQueryString = (queryString: Search) => Query;
+export type StringifyQuery = (queryObject: Query) => Search;
+
+type AnyFunction = (...args: any[]) => any;
+
+export type EnterHook = (
+  nextState: RouterState,
+  replace: RedirectFunction,
+  callback?: AnyFunction
+) => any;
+export type LeaveHook = (prevState: RouterState) => any;
+export type ChangeHook = (
+  prevState: RouterState,
+  nextState: RouterState,
+  replace: RedirectFunction,
+  callback?: AnyFunction
+) => any;
+export type RouteHook = (nextLocation?: Location) => any;
+
+export interface RedirectFunction {
+  (location: LocationDescriptor): void;
+  (state: LocationState, pathname: Pathname | Path, query?: Query): void;
+}
+
+export interface RouterState<Q = any> {
+  location: Location<Q>;
+  routes: PlainRoute[];
+  params: Params;
+  components: RouteComponent[];
+}
+
+type LocationFunction = (location: LocationDescriptor) => void;
+type GoFunction = (n: number) => void;
+type NavigateFunction = () => void;
+type ActiveFunction = (
+  location: LocationDescriptor,
+  indexOnly?: boolean
+) => boolean;
+type LeaveHookFunction = (route: any, callback: RouteHook) => () => void;
+type CreatePartFunction<Part> = (
+  pathOrLoc: LocationDescriptor,
+  query?: any
+) => Part;
+
+export interface InjectedRouter {
+  push: LocationFunction;
+  replace: LocationFunction;
+  go: GoFunction;
+  goBack: NavigateFunction;
+  goForward: NavigateFunction;
+  setRouteLeaveHook: LeaveHookFunction;
+  createPath: CreatePartFunction<Path>;
+  createHref: CreatePartFunction<Href>;
+  isActive: ActiveFunction;
+}
+
+export interface RouteComponentProps<P, R, ComponentProps = any, Q = any> {
+  location: Location<Q>;
+  params: P & R;
+  route: PlainRoute<ComponentProps>;
+  router: InjectedRouter;
+  routes: PlainRoute[];
+  routeParams: R;
+}
+
+export interface RouterProps extends ClassAttributes<any> {
+  children?: React.ReactNode;
+  routes?: RouteConfig | undefined;
+  history?: History | undefined;
+  createElement?(component: RouteComponent, props: any): any;
+  onError?(error: any): any;
+  onUpdate?(): any;
+  render?(props: any): ReactNode;
+}
+
+type Router = ComponentClass<RouterProps>;
+declare const Router: Router
+
+export default Router

--- a/types/lib/RouterContext.d.ts
+++ b/types/lib/RouterContext.d.ts
@@ -1,0 +1,6 @@
+import { ComponentClass } from 'react'
+
+type RouterContext = ComponentClass<any>;
+declare const RouterContext: RouterContext
+
+export default RouterContext

--- a/types/lib/RouterContext.d.ts
+++ b/types/lib/RouterContext.d.ts
@@ -1,4 +1,8 @@
-import { FunctionComponent } from 'react'
+import { Context, FunctionComponent } from 'react'
+
+import { InjectedRouter } from './Router'
+
+export declare const routerContext: Context<InjectedRouter>
 
 type RouterContext = FunctionComponent<any>;
 declare const RouterContext: RouterContext

--- a/types/lib/RouterContext.d.ts
+++ b/types/lib/RouterContext.d.ts
@@ -1,6 +1,6 @@
-import { ComponentClass } from 'react'
+import { FunctionComponent } from 'react'
 
-type RouterContext = ComponentClass<any>;
+type RouterContext = FunctionComponent<any>;
 declare const RouterContext: RouterContext
 
 export default RouterContext

--- a/types/lib/applyRouterMiddleware.d.ts
+++ b/types/lib/applyRouterMiddleware.d.ts
@@ -1,0 +1,11 @@
+import { RouteComponent } from '..'
+import RouterContext from './RouterContext'
+
+export interface Middleware {
+  renderRouterContext?(previous: RouterContext, props: any): RouterContext;
+  renderRouteComponent?(previous: RouteComponent, props: any): RouteComponent;
+}
+
+export default function applyRouterMiddleware(
+  ...middlewares: Middleware[]
+): (renderProps: any) => RouterContext

--- a/types/lib/browserHistory.d.ts
+++ b/types/lib/browserHistory.d.ts
@@ -1,0 +1,5 @@
+import { History } from 'history'
+
+declare const browserHistory: History
+
+export default browserHistory

--- a/types/lib/createMemoryHistory.d.ts
+++ b/types/lib/createMemoryHistory.d.ts
@@ -1,0 +1,2 @@
+import { default as createMemoryHistory } from 'history/lib/createMemoryHistory'
+export default createMemoryHistory

--- a/types/lib/hashHistory.d.ts
+++ b/types/lib/hashHistory.d.ts
@@ -1,0 +1,5 @@
+import { History } from 'history'
+
+declare const hashHistory: History
+
+export default hashHistory

--- a/types/lib/match.d.ts
+++ b/types/lib/match.d.ts
@@ -1,0 +1,30 @@
+import { Basename, History, Location, LocationDescriptor } from 'history'
+import { ParseQueryString, RouteConfig, StringifyQuery } from '..'
+
+export interface MatchArgs {
+  routes: RouteConfig;
+  basename?: Basename | undefined;
+  parseQueryString?: ParseQueryString | undefined;
+  stringifyQuery?: StringifyQuery | undefined;
+}
+
+export interface MatchLocationArgs extends MatchArgs {
+  location: LocationDescriptor;
+  history?: History | undefined;
+}
+
+export interface MatchHistoryArgs extends MatchArgs {
+  location?: LocationDescriptor | undefined;
+  history: History;
+}
+
+export type MatchCallback = (
+  error: any,
+  redirectLocation: Location,
+  renderProps: any
+) => void;
+
+export default function match(
+  args: MatchLocationArgs | MatchHistoryArgs,
+  cb: MatchCallback
+): void

--- a/types/lib/useRouterHistory.d.ts
+++ b/types/lib/useRouterHistory.d.ts
@@ -1,0 +1,3 @@
+import { CreateHistory, HistoryBasename, HistoryBasenameOptions, HistoryQueries } from 'history'
+
+export default function useRouterHistory<O, H>(createHistory: CreateHistory<O, H>): CreateHistory<O & HistoryBasenameOptions, H & HistoryBasename & HistoryQueries>

--- a/types/lib/withRouter.d.ts
+++ b/types/lib/withRouter.d.ts
@@ -3,10 +3,6 @@ import { InjectedRouter, Params } from './Router'
 import { Location } from 'history'
 import { PlainRoute } from './Route'
 
-interface Options {
-    withRef?: boolean | undefined;
-}
-
 export interface WithRouterProps<P = Params, Q = any> {
     location: Location<Q>;
     params: P;
@@ -18,11 +14,9 @@ type ComponentConstructor<P> = ComponentClass<P> | FunctionComponent<P>;
 
 declare function withRouter<P, S>(
     component: ComponentConstructor<P & WithRouterProps> & S,
-    options?: Options
 ): ComponentClass<Omit<P, keyof WithRouterProps>> & S;
 declare function withRouter<P>(
     component: ComponentConstructor<P & WithRouterProps>,
-    options?: Options
 ): ComponentClass<Omit<P, keyof WithRouterProps>>;
 
 export default withRouter

--- a/types/lib/withRouter.d.ts
+++ b/types/lib/withRouter.d.ts
@@ -1,22 +1,22 @@
-import { ComponentClass, FunctionComponent } from 'react'
+import { FunctionComponent, FunctionComponent } from 'react'
 import { InjectedRouter, Params } from './Router'
 import { Location } from 'history'
 import { PlainRoute } from './Route'
 
 export interface WithRouterProps<P = Params, Q = any> {
-    location: Location<Q>;
-    params: P;
-    router: InjectedRouter;
-    routes: PlainRoute[];
+  location: Location<Q>;
+  params: P;
+  router: InjectedRouter;
+  routes: PlainRoute[];
 }
 
-type ComponentConstructor<P> = ComponentClass<P> | FunctionComponent<P>;
+type ComponentConstructor<P> = FunctionComponent<P> | FunctionComponent<P>;
 
 declare function withRouter<P, S>(
-    component: ComponentConstructor<P & WithRouterProps> & S,
-): ComponentClass<Omit<P, keyof WithRouterProps>> & S;
+  component: ComponentConstructor<P & WithRouterProps> & S
+): FunctionComponent<Omit<P, keyof WithRouterProps>> & S;
 declare function withRouter<P>(
-    component: ComponentConstructor<P & WithRouterProps>,
-): ComponentClass<Omit<P, keyof WithRouterProps>>;
+  component: ComponentConstructor<P & WithRouterProps>
+): FunctionComponent<Omit<P, keyof WithRouterProps>>;
 
 export default withRouter

--- a/types/lib/withRouter.d.ts
+++ b/types/lib/withRouter.d.ts
@@ -1,0 +1,28 @@
+import { ComponentClass, FunctionComponent } from 'react'
+import { InjectedRouter, Params } from './Router'
+import { Location } from 'history'
+import { PlainRoute } from './Route'
+
+interface Options {
+    withRef?: boolean | undefined;
+}
+
+export interface WithRouterProps<P = Params, Q = any> {
+    location: Location<Q>;
+    params: P;
+    router: InjectedRouter;
+    routes: PlainRoute[];
+}
+
+type ComponentConstructor<P> = ComponentClass<P> | FunctionComponent<P>;
+
+declare function withRouter<P, S>(
+    component: ComponentConstructor<P & WithRouterProps> & S,
+    options?: Options
+): ComponentClass<Omit<P, keyof WithRouterProps>> & S;
+declare function withRouter<P>(
+    component: ComponentConstructor<P & WithRouterProps>,
+    options?: Options
+): ComponentClass<Omit<P, keyof WithRouterProps>>;
+
+export default withRouter

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
+"@types/history@3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-3.2.5.tgz#be614208f1a10a20c414b4d3762d1f2b65b53ae4"
+  integrity sha512-TqWYI0mlqS5qhH8MHgJJs0RcgvvZLxkn0bi2qK07liZqP7M9rl1kpJ6TCAUo5Cp4vP5DObIqHcky0MWyyQojVQ==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,12 +1015,12 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
-"@nodelib/fs.walk@^1.2.8":
+"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
@@ -1091,6 +1091,52 @@
   integrity sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==
   dependencies:
     undici-types "~6.20.0"
+
+"@typescript-eslint/parser@^8.18.0":
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.18.0.tgz#a1c9456cbb6a089730bf1d3fc47946c5fb5fe67b"
+  integrity sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==
+  dependencies:
+    "@typescript-eslint/scope-manager" "8.18.0"
+    "@typescript-eslint/types" "8.18.0"
+    "@typescript-eslint/typescript-estree" "8.18.0"
+    "@typescript-eslint/visitor-keys" "8.18.0"
+    debug "^4.3.4"
+
+"@typescript-eslint/scope-manager@8.18.0":
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.18.0.tgz#30b040cb4557804a7e2bcc65cf8fdb630c96546f"
+  integrity sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==
+  dependencies:
+    "@typescript-eslint/types" "8.18.0"
+    "@typescript-eslint/visitor-keys" "8.18.0"
+
+"@typescript-eslint/types@8.18.0":
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.18.0.tgz#3afcd30def8756bc78541268ea819a043221d5f3"
+  integrity sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==
+
+"@typescript-eslint/typescript-estree@8.18.0":
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.0.tgz#d8ca785799fbb9c700cdff1a79c046c3e633c7f9"
+  integrity sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==
+  dependencies:
+    "@typescript-eslint/types" "8.18.0"
+    "@typescript-eslint/visitor-keys" "8.18.0"
+    debug "^4.3.4"
+    fast-glob "^3.3.2"
+    is-glob "^4.0.3"
+    minimatch "^9.0.4"
+    semver "^7.6.0"
+    ts-api-utils "^1.3.0"
+
+"@typescript-eslint/visitor-keys@8.18.0":
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.0.tgz#7b6d33534fa808e33a19951907231ad2ea5c36dd"
+  integrity sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==
+  dependencies:
+    "@typescript-eslint/types" "8.18.0"
+    eslint-visitor-keys "^4.2.0"
 
 "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
@@ -1756,7 +1802,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.2, braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -2301,7 +2347,7 @@ date-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
   integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
 
-debug@*, debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
+debug@*, debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
@@ -2728,6 +2774,11 @@ eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
+eslint-visitor-keys@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz#687bacb2af884fcdda8a6e7d65c606f46a14cd45"
+  integrity sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==
+
 eslint@^8.0.0:
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
@@ -2915,6 +2966,17 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-glob@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -3180,19 +3242,19 @@ get-symbol-description@^1.0.2:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
 
+glob-parent@^5.1.2, glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
-
-glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
@@ -4206,10 +4268,23 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
+
+micromatch@^4.0.4:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -4247,7 +4322,7 @@ minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatc
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^9.0.3:
+minimatch@^9.0.3, minimatch@^9.0.4:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
@@ -4630,7 +4705,7 @@ picocolors@^1.0.0, picocolors@^1.1.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -5366,7 +5441,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.4:
+semver@^7.5.4, semver@^7.6.0:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
@@ -5875,6 +5950,11 @@ tree-dump@^1.0.1:
   resolved "https://registry.yarnpkg.com/tree-dump/-/tree-dump-1.0.2.tgz#c460d5921caeb197bde71d0e9a7b479848c5b8ac"
   integrity sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==
 
+ts-api-utils@^1.3.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz#bfc2215fe6528fecab2b0fba570a2e8a4263b064"
+  integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
+
 tslib@^2.0.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
@@ -5944,6 +6024,11 @@ typed-array-length@^1.0.6:
     is-typed-array "^1.1.13"
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
+
+typescript@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 ultron@~1.1.0:
   version "1.1.1"


### PR DESCRIPTION
React router v3 comes with types via `@types/react-router`. If we want true compat, this library should come with them too. But `@types/react-router` won't work as the name doesn't match. Also our runtime drifts a bit.

So we should fork the library in here + apply the modifications.

This is what this PR does:
- create a new folder `types/`
- update all of them to FC instead of classes
- remove `withRef` in `withRouter`
- add `routerContext`
- set up the parser, dependencies, peer dependencies