### PR TITLE
fix deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,12 @@
     "*.md",
     "es",
     "lib",
-    "umd",
-    "types"
+    "umd"
   ],
   "types": "types/index.d.ts",
-  "main": "lib/index",
-  "module": "es/index",
-  "jsnext:main": "es/index",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
   "repository": "https://github.com/Ayc0/react-router-v3",
   "homepage": "https://github.com/Ayc0/react-router-v3#readme",
   "bugs": "https://github.com/Ayc0/react-router-v3/issues",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.3.0-alpha.2",
   "description": "A complete routing library for React",
   "files": [
-    "*.md",
     "es",
     "lib",
     "umd"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -18,3 +18,6 @@ console.log(
     gzipSize.sync(readFileSync('umd/ReactRouter.min.js'))
   )
 )
+
+exec('cp types/index.d.ts lib/')
+exec('cp types/lib/* lib/')


### PR DESCRIPTION
People importing files like `react-router/lib/Router` can't right now, this fixes this